### PR TITLE
Updating graphql client to take arbitrary schema

### DIFF
--- a/lib/shopify_api/resources/graphql.rb
+++ b/lib/shopify_api/resources/graphql.rb
@@ -5,15 +5,15 @@ require 'graphql/client/http'
 module ShopifyAPI
   # GraphQL API.
   class GraphQL
-    def initialize
+    def initialize(path = '/admin/api/2020-10/graphql.json', schema = nil )
       uri = Base.site.dup
-      uri.path = '/admin/api/2020-10/graphql.json'
+      uri.path = path
       @http = ::GraphQL::Client::HTTP.new(uri.to_s) do
         define_method(:headers) do |_context|
           Base.headers
         end
       end
-      #@schema = ::GraphQL::Client.load_schema(@http)
+      @schema = schema || ::GraphQL::Client.load_schema(@http)
       @client = ::GraphQL::Client.new(schema: ::GraphQL::Schema.new, execute: @http)
     end
 

--- a/lib/shopify_api/resources/graphql.rb
+++ b/lib/shopify_api/resources/graphql.rb
@@ -7,7 +7,7 @@ module ShopifyAPI
   class GraphQL
     def initialize
       uri = Base.site.dup
-      uri.path = '/admin/api/graphql.json'
+      uri.path = '/admin/api/2020-10/graphql.json'
       @http = ::GraphQL::Client::HTTP.new(uri.to_s) do
         define_method(:headers) do |_context|
           Base.headers

--- a/lib/shopify_api/resources/graphql.rb
+++ b/lib/shopify_api/resources/graphql.rb
@@ -13,7 +13,7 @@ module ShopifyAPI
           Base.headers
         end
       end
-      @schema = ::GraphQL::Client.load_schema(@http)
+      #@schema = ::GraphQL::Client.load_schema(@http)
       @client = ::GraphQL::Client.new(schema: ::GraphQL::Schema.new, execute: @http)
     end
 

--- a/lib/shopify_api/resources/graphql.rb
+++ b/lib/shopify_api/resources/graphql.rb
@@ -14,7 +14,7 @@ module ShopifyAPI
         end
       end
       @schema = ::GraphQL::Client.load_schema(@http)
-      @client = ::GraphQL::Client.new(schema: @schema, execute: @http)
+      @client = ::GraphQL::Client.new(schema: ::GraphQL::Schema.new, execute: @http)
     end
 
     delegate :parse, :query, to: :@client

--- a/lib/shopify_api/resources/graphql.rb
+++ b/lib/shopify_api/resources/graphql.rb
@@ -14,7 +14,7 @@ module ShopifyAPI
         end
       end
       @schema = schema || ::GraphQL::Client.load_schema(@http)
-      @client = ::GraphQL::Client.new(schema: ::GraphQL::Schema.new, execute: @http)
+      @client = ::GraphQL::Client.new(schema: @schema, execute: @http)
     end
 
     delegate :parse, :query, to: :@client


### PR DESCRIPTION
To use the graphql client the schema needs to be loaded. The schema is no longer served via the endpoint (this gem is over 2 years old) so we must supply it manually.